### PR TITLE
Add skipped test xml support

### DIFF
--- a/src/utils/__snapshots__/buildXmlReport.spec.ts.snap
+++ b/src/utils/__snapshots__/buildXmlReport.spec.ts.snap
@@ -19,6 +19,11 @@ exports[`buildXmlReport full report 1`] = `
             <failure message=\\"Lorem ipsum\\"><![CDATA[Lorem ipsum]]></failure>
         </testCase>
     </file>
+    <file path=\\"test/BazTest.js\\">
+        <testCase name=\\"Skipped test\\" duration=\\"5\\">
+            <skipped/>
+        </testCase>
+    </file>
 </testExecutions>"
 `;
 

--- a/src/utils/buildJsonResults.ts
+++ b/src/utils/buildJsonResults.ts
@@ -62,6 +62,7 @@ export default (report: any, appDirectory: any, options: any): any => {
         'tests': 0,
         'failures': 0,
         'errors': 0,
+        'skipped': 0,
         // Overall execution time:
         // Since tests are typically executed in parallel this time can be significantly smaller
         // than the sum of the individual test suites
@@ -124,6 +125,7 @@ export default (report: any, appDirectory: any, options: any): any => {
 
     // Update top level testsuites properties
     jsonResults.testsuites[0]._attr.failures += suite.numFailingTests;
+    jsonResults.testsuites[0]._attr.skipped += suite.numPendingTests;
     jsonResults.testsuites[0]._attr.errors += suiteErrors;
     jsonResults.testsuites[0]._attr.tests += suiteNumTests;
 

--- a/src/utils/buildJsonResults.ts
+++ b/src/utils/buildJsonResults.ts
@@ -237,3 +237,4 @@ export default (report: any, appDirectory: any, options: any): any => {
 
   return jsonResults;
 };
+

--- a/src/utils/buildJsonResults.ts
+++ b/src/utils/buildJsonResults.ts
@@ -237,4 +237,3 @@ export default (report: any, appDirectory: any, options: any): any => {
 
   return jsonResults;
 };
-

--- a/src/utils/buildXmlReport.spec.ts
+++ b/src/utils/buildXmlReport.spec.ts
@@ -59,6 +59,16 @@ describe('buildXmlReport', () => {
               status: 'failed',
             }
           ]
+        },
+        {
+          testFilePath: 'test/BazTest.js',
+          testResults: [
+            {
+              duration: 5,
+              fullName: 'Skipped test',
+              status: 'pending',
+            }
+          ]
         }
       ]
     }

--- a/src/utils/xml/__snapshots__/testCase.spec.ts.snap
+++ b/src/utils/xml/__snapshots__/testCase.spec.ts.snap
@@ -7,3 +7,9 @@ exports[`testCase failing test case 1`] = `
     <failure message=\\"Lorem ipsum\\"><![CDATA[Lorem ipsum]]></failure>
 </testCase>"
 `;
+
+exports[`testCase skipped test case 1`] = `
+"<testCase name=\\"lorem ipsum\\" duration=\\"0\\">
+    <skipped/>
+</testCase>"
+`;

--- a/src/utils/xml/testCase.spec.ts
+++ b/src/utils/xml/testCase.spec.ts
@@ -23,7 +23,21 @@ describe('testCase', () => {
       status: 'failed',
       title: 'lorem ipsum'
     }
- 
+
+    // Act
+    const actualReport = xml(testCase(mock), true)
+
+    // Assert
+    expect(actualReport).toMatchSnapshot()
+  })
+
+  test('skipped test case', () => {
+    // Arrange
+    const mock = {
+      status: 'pending',
+      title: 'lorem ipsum'
+    }
+
     // Act
     const actualReport = xml(testCase(mock), true)
 

--- a/src/utils/xml/testCase.ts
+++ b/src/utils/xml/testCase.ts
@@ -12,6 +12,8 @@ export const testCase = (testResult: any): any => {
   if (testResult.status === 'failed') {
     failures = testResult.failureMessages.map(failure)
     return {testCase: [aTestCase].concat(failures)}
-  } 
+  } else if (testResult.status === 'pending') {
+    return {testCase: [aTestCase].concat({ skipped: {} } as any)};
+  }
   return {testCase: aTestCase}
 }


### PR DESCRIPTION
Fixes #

There is an issue where skipped tests are not indicated in the XML output for the Sonar report with Jest.

Changes proposed in this pull request:
* Added support in the XML processing to include the <skipped/> tag in the test that is skipped
* Tested with Sonar, now showing the skipped tests
* Added unit tests to verify that skipped tests are properly indicated in the XML output.

