### PR TITLE
Add projectRoot option for relativePaths

### DIFF
--- a/src/constants/index.ts
+++ b/src/constants/index.ts
@@ -17,6 +17,7 @@ export default {
     JEST_USE_PATH_FOR_SUITE_NAME: 'usePathForSuiteName',
     JEST_SONAR_TEST_SUITE_PROPERTIES_JSON_FILE: 'testSuitePropertiesFile',
     JEST_SONAR_RELATIVE_PATHS: 'relativePaths',
+    JEST_SONAR_PROJECT_ROOT: 'projectRoot',
     JEST_SONAR_56_FORMAT: 'formatForSonar56'
   },
   DEFAULT_OPTIONS: {
@@ -36,6 +37,7 @@ export default {
     noStackTrace: false,
     testSuitePropertiesFile: 'jestSonarProperties.js',
     relativePaths: false,
+    projectRoot: null,
     formatForSonar56: false
   },
   SUITENAME_VAR: 'suitename',

--- a/src/utils/buildXmlReport.ts
+++ b/src/utils/buildXmlReport.ts
@@ -2,7 +2,7 @@ import file from './xml/file';
 
 export default (data: any, options: any = {}): any => {
   const aTestExecution = [{_attr: {version: '1'}}]
-  const testResults = data.testResults.map((result: any) => { return file(result, options.relativePaths) })
+  const testResults = data.testResults.map((result: any) => { return file(result, options.relativePaths, options.projectRoot) })
 
   return options?.formatForSonar56
     ? { unitTest: aTestExecution.concat(testResults) }

--- a/src/utils/xml/__snapshots__/file.spec.ts.snap
+++ b/src/utils/xml/__snapshots__/file.spec.ts.snap
@@ -2,6 +2,11 @@
 
 exports[`file <file path=""></file> 1`] = `"<file path=\\"test/FooTest.js\\"></file>"`;
 
+exports[`file testCase projectRoot 1`] = `
+"<file path=\\"FooTest.js\\">
+</file>"
+`;
+
 exports[`file testCase tag 1`] = `
 "<file path=\\"test/FooTest.js\\">
     <testCase name=\\"lorem ipsum\\" duration=\\"0\\"/>

--- a/src/utils/xml/file.spec.ts
+++ b/src/utils/xml/file.spec.ts
@@ -10,7 +10,7 @@ describe('file', () => {
     }
 
     // Act
-    const actualReport = xml(file(mock, false))
+    const actualReport = xml(file(mock, false, null))
 
     // Assert
     expect(actualReport).toMatchSnapshot()
@@ -27,8 +27,21 @@ describe('file', () => {
     }
 
     // Act
+    const actualReport = xml(file(mock, false, null), true)
 
-    const actualReport = xml(file(mock, false), true)
+    // Assert
+    expect(actualReport).toMatchSnapshot()
+  })
+
+  test('testCase projectRoot', () => {
+    // Arrange
+    const mock = {
+      testFilePath: 'test/FooTest.js',
+      testResults: []
+    }
+
+    // Act
+    const actualReport = xml(file(mock, true, 'test'), true)
 
     // Assert
     expect(actualReport).toMatchSnapshot()

--- a/src/utils/xml/file.ts
+++ b/src/utils/xml/file.ts
@@ -1,11 +1,12 @@
 import { testCase } from './testCase';
 import * as path from 'path';
 
-export default (testResult: any, relativePaths = false): any  => {
+export default (testResult: any, relativePaths = false, projectRoot: string | null): any  => {
     let aFile: any;
 
-    if(relativePaths){
-        aFile = [{_attr: { path: path.relative(process.cwd(), testResult.testFilePath) } }];
+    if (relativePaths) {
+        const relativeRoot = projectRoot == null ? process.cwd() : path.resolve(projectRoot);
+        aFile = [{_attr: { path: path.relative(relativeRoot, testResult.testFilePath) } }];
     } else {
         aFile = [{_attr: { path: testResult.testFilePath }}];
     }


### PR DESCRIPTION
Changes proposed in this pull request:
* Add projectRoot option for relativePaths

This is useful for monorepos where the `cwd` of the tests execution may not be the directory of the project.

## Usage
```javascript
// jest.config.js
module.exports = {
  // ...
  reporters: [
    "default",
    [
      "@casualbot/jest-sonar-reporter",
      {
        relativePaths: true,
        projectRoot: __dirname,
        outputDirectory: "coverageDir/project1",
        outputName: "sonar-report.xml",
      },
    ],
  ]
}
```