### PR TITLE
Add `files` to solve NPM 10 `lib/src` strip problem

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "typescript"
   ],
   "main": "lib/index.js",
+  "files": [ "lib", "lib/src" ],
   "scripts": {
     "test": "tsc --module commonjs && jest",
     "test:watch": "jest --watch",


### PR DESCRIPTION
Since NPM 10, the `lib/src` dir is being stripped out. This doesn't happen on NPM 9.

This causes the following error:
```
Cannot find module './src/utils/buildXmlReport'
   Require stack:
   - /path/to/node_modules/@casualbot/jest-sonar-reporter/lib/index.js
   - /path/to/node_modules/jest-util/build/requireOrImportModule.js
   - /path/to/node_modules/jest-util/build/index.js
   - /path/to/node_modules/jest-config/build/getCacheDirectory.js
   - /path/to/node_modules/jest-config/build/Defaults.js
   - /path/to/node_modules/jest-config/build/normalize.js
   - /path/to/node_modules/jest-config/build/index.js
```