### PR TITLE
Fix SonarCloud support

### DIFF
--- a/src/utils/__snapshots__/buildXmlReport.spec.ts.snap
+++ b/src/utils/__snapshots__/buildXmlReport.spec.ts.snap
@@ -21,7 +21,7 @@ exports[`buildXmlReport full report 1`] = `
     </file>
     <file path=\\"test/BazTest.js\\">
         <testCase name=\\"Skipped test\\" duration=\\"5\\">
-            <skipped/>
+            <skipped message=\\"Test skipped\\"/>
         </testCase>
     </file>
 </testExecutions>"

--- a/src/utils/xml/__snapshots__/testCase.spec.ts.snap
+++ b/src/utils/xml/__snapshots__/testCase.spec.ts.snap
@@ -10,6 +10,6 @@ exports[`testCase failing test case 1`] = `
 
 exports[`testCase skipped test case 1`] = `
 "<testCase name=\\"lorem ipsum\\" duration=\\"0\\">
-    <skipped/>
+    <skipped message=\\"Test skipped\\"/>
 </testCase>"
 `;

--- a/src/utils/xml/testCase.ts
+++ b/src/utils/xml/testCase.ts
@@ -13,7 +13,15 @@ export const testCase = (testResult: any): any => {
     failures = testResult.failureMessages.map(failure)
     return {testCase: [aTestCase].concat(failures)}
   } else if (testResult.status === 'pending') {
-    return {testCase: [aTestCase].concat({ skipped: {} } as any)};
+    return {
+      testCase: [aTestCase].concat({
+        skipped: {
+          _attr: {
+            message: "Test skipped"
+          },
+        },
+      } as any),
+    };
   }
   return {testCase: aTestCase}
 }


### PR DESCRIPTION
https://github.com/CasualBot/jest-sonar-reporter/pull/11 added support for reporting `skipped` tests to Sonar, but failed to support SonarQube <=9.6 and SonarCloud (now known as SonarQube-Cloud)

See docs https://docs.sonarsource.com/sonarqube-cloud/enriching/test-coverage/generic-test-data/#generic-execution which specify `message` as mandatory.

Error without this patch looks like 

```
ERROR: Error during parsing of generic test execution report '/github/workspace/coverage/jest-sonar-reporter-691e45f0-79c3-11ef-92de-2d87ce8c40b3.xml'. Look at the SonarQube documentation to know the expected XML format.
ERROR: Caused by: Missing attribute "message" in element "skipped" at line 243
```

https://github.com/matrix-org/matrix-js-sdk/pull/4421 for an example blocked PR.