### PR TITLE
fix: replace uuid dependency with node:crypto randomUUID

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,6 @@
       "license": "MIT",
       "dependencies": {
         "mkdirp": "1.0.4",
-        "uuid": "8.3.2",
         "xml": "1.0.1"
       },
       "devDependencies": {
@@ -23,7 +22,6 @@
         "@types/jest": "27.0.3",
         "@types/mkdirp": "1.0.2",
         "@types/node": "16.11.12",
-        "@types/uuid": "8.3.3",
         "@types/xml": "1.0.6",
         "@typescript-eslint/eslint-plugin": "^5.6.0",
         "@typescript-eslint/parser": "^5.6.0",
@@ -2382,12 +2380,6 @@
       "integrity": "sha512-9aEbYZ3TbYMznPdcdr3SmIrLXwC/AKZXQeCf9Pgao5CKb8CyHuEX5jzWPTkvregvhRJHcpRO6BFoGW9ycaOkYw==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/@types/uuid": {
-      "version": "8.3.3",
-      "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-8.3.3.tgz",
-      "integrity": "sha512-0LbEEx1zxrYB3pgpd1M5lEhLcXjKJnYghvhTRgaBeUivLHMDM1TzF3IJ6hXU2+8uA4Xz+5BA63mtZo5DjVT8iA==",
-      "dev": true
     },
     "node_modules/@types/xml": {
       "version": "1.0.6",
@@ -7925,14 +7917,6 @@
         "requires-port": "^1.0.0"
       }
     },
-    "node_modules/uuid": {
-      "version": "8.3.2",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
-      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
-      "bin": {
-        "uuid": "dist/bin/uuid"
-      }
-    },
     "node_modules/v8-compile-cache": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/v8-compile-cache/-/v8-compile-cache-2.3.0.tgz",
@@ -9895,12 +9879,6 @@
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/@types/stack-utils/-/stack-utils-2.0.3.tgz",
       "integrity": "sha512-9aEbYZ3TbYMznPdcdr3SmIrLXwC/AKZXQeCf9Pgao5CKb8CyHuEX5jzWPTkvregvhRJHcpRO6BFoGW9ycaOkYw==",
-      "dev": true
-    },
-    "@types/uuid": {
-      "version": "8.3.3",
-      "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-8.3.3.tgz",
-      "integrity": "sha512-0LbEEx1zxrYB3pgpd1M5lEhLcXjKJnYghvhTRgaBeUivLHMDM1TzF3IJ6hXU2+8uA4Xz+5BA63mtZo5DjVT8iA==",
       "dev": true
     },
     "@types/xml": {
@@ -13854,11 +13832,6 @@
         "querystringify": "^2.1.1",
         "requires-port": "^1.0.0"
       }
-    },
-    "uuid": {
-      "version": "8.3.2",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
-      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg=="
     },
     "v8-compile-cache": {
       "version": "2.3.0",

--- a/package.json
+++ b/package.json
@@ -55,7 +55,6 @@
     "@types/jest": "27.0.3",
     "@types/mkdirp": "1.0.2",
     "@types/node": "16.11.12",
-    "@types/uuid": "8.3.3",
     "@types/xml": "1.0.6",
     "@typescript-eslint/eslint-plugin": "^5.6.0",
     "@typescript-eslint/parser": "^5.6.0",
@@ -76,7 +75,6 @@
   },
   "dependencies": {
     "mkdirp": "1.0.4",
-    "uuid": "8.3.2",
     "xml": "1.0.1"
   },
   "overrides": {

--- a/src/utils/getOptions.ts
+++ b/src/utils/getOptions.ts
@@ -1,7 +1,7 @@
 // Copied from https://raw.githubusercontent.com/jest-community/jest-junit/master/utils/getOptions.js
 import * as path from 'path';
 import * as fs from 'fs';
-import { v1 as uuid } from 'uuid';
+import { randomUUID } from 'node:crypto';
 import constants from '../constants';
 import { replaceRootDirInPath } from './replaceRootDirInPath';
 
@@ -61,7 +61,7 @@ function replaceRootDirInOutput(rootDir: any, output: any) {
 }
 
 function getUniqueOutputName() {
-  return `jest-sonar-reporter-${uuid()}.xml`
+  return `jest-sonar-reporter-${randomUUID()}.xml`
 }
 
 export default {


### PR DESCRIPTION
## Summary

- Removes the third-party `uuid` package (affected by [GHSA-w5hq-g745-h8pq](https://github.com/uuidjs/uuid/security/advisories/GHSA-w5hq-g745-h8pq)) in favor of Node's built-in `crypto.randomUUID()`
- Also removes the now-unnecessary `@types/uuid` dev dependency
- `randomUUID()` has been available since Node 14.17.0 — no compatibility concerns

Closes #45

## Test plan

- [x] `npm run build` passes
- [x] `npm test` — all 7 suites pass, 0 vulnerabilities reported